### PR TITLE
Only push on new documents

### DIFF
--- a/lib/bloc/pagination_cubit.dart
+++ b/lib/bloc/pagination_cubit.dart
@@ -107,9 +107,18 @@ class PaginationCubit extends Cubit<PaginationState> {
   }) {
     _lastDocument = newList.isNotEmpty ? newList.last : null;
     emit(PaginationLoaded(
-      documentSnapshots: previousList + newList,
+      documentSnapshots: _mergeSnapshots(previousList, newList),
       hasReachedEnd: newList.isEmpty,
     ));
+  }
+
+  List<QueryDocumentSnapshot> _mergeSnapshots(
+    List<QueryDocumentSnapshot> previousList,
+    List<QueryDocumentSnapshot> newList,
+  ) {
+    final prevIds = previousList.map((prevSnapshot) => prevSnapshot.id).toSet();
+    newList.retainWhere((newSnapshot) => prevIds.add(newSnapshot.id));
+    return previousList + newList;
   }
 
   Query _getQuery() {


### PR DESCRIPTION
Related issue: https://github.com/vedartm/paginate_firestore/issues/72
Thanks @itssidhere for creating the issue

Added _mergeSnapshots function to only push on new items by document id onto previousList
This allows for the order to be preserved, which was a noted concern with using a set.

