### PR TITLE
expose allowImplicitScrolling to allow for preloading before/after page

### DIFF
--- a/lib/paginate_firestore.dart
+++ b/lib/paginate_firestore.dart
@@ -39,6 +39,7 @@ class PaginateFirestore extends StatefulWidget {
     this.physics,
     this.listeners,
     this.scrollController,
+    this.allowImplicitScrolling = false,
     this.pageController,
     this.onPageChanged,
     this.header,
@@ -57,6 +58,7 @@ class PaginateFirestore extends StatefulWidget {
   final ScrollPhysics? physics;
   final Query query;
   final bool reverse;
+  final bool allowImplicitScrolling;
   final ScrollController? scrollController;
   final PageController? pageController;
   final Axis scrollDirection;
@@ -264,6 +266,7 @@ class _PaginateFirestoreState extends State<PaginateFirestore> {
       padding: widget.padding,
       child: PageView.custom(
         reverse: widget.reverse,
+        allowImplicitScrolling: widget.allowImplicitScrolling,
         controller: widget.pageController,
         scrollDirection: widget.scrollDirection,
         physics: widget.physics,


### PR DESCRIPTION
I need the ability to preload network images and according to https://github.com/flutter/flutter/issues/31191, adding `allowImplicitScrolling` can preload before and after page. Another option would be to use https://pub.dev/packages/preload_page_view, but that requires an additional dependency and some rework. Exposing `allowImplicitScrolling` seemed to the be most non-intrusive way to accomplish this.