### PR TITLE
Resolve race condition for live option

### DIFF
--- a/lib/bloc/pagination_cubit.dart
+++ b/lib/bloc/pagination_cubit.dart
@@ -94,11 +94,12 @@ class PaginationCubit extends Cubit<PaginationState> {
     if (state is PaginationInitial) {
       refreshPaginatedList();
     } else if (state is PaginationLoaded) {
-      final loadedState = state as PaginationLoaded;
+      PaginationLoaded loadedState = state as PaginationLoaded;
       if (loadedState.hasReachedEnd) return;
       final listener = localQuery
           .snapshots(includeMetadataChanges: includeMetadataChanges)
           .listen((querySnapshot) {
+        loadedState = state as PaginationLoaded;
         _emitPaginatedState(
           querySnapshot.docs,
           previousList:


### PR DESCRIPTION
Resolve race condition by using an updated state when getting the previousList for _emitPaginatedState

Related issue: https://github.com/vedartm/paginate_firestore/issues/120